### PR TITLE
adds 'getClient' method to provide access to native redis client

### DIFF
--- a/index.js
+++ b/index.js
@@ -144,6 +144,21 @@ function redisStore(args) {
     return value !== null && value !== undefined;
   };
 
+  self.getClient = function(cb) {
+    connect(function (err, conn) {
+      if (err) {
+        return cb && cb(err);
+      }
+      cb(null, {
+        client: conn,
+        done: function(done) {
+          pool.release(conn);
+          if (done && typeof done === 'function') done();
+        }
+      });
+    });
+  };
+
   return self;
 }
 

--- a/index.js
+++ b/index.js
@@ -152,8 +152,9 @@ function redisStore(args) {
       cb(null, {
         client: conn,
         done: function(done) {
+          var args = Array.prototype.slice.call(arguments, 1);
           pool.release(conn);
-          if (done && typeof done === 'function') done();
+          if (done && typeof done === 'function') done.apply(null, args);
         }
       });
     });


### PR DESCRIPTION
closes #11 and can be used like so:

```javascript
// get a redis client from the pool
redisCache.store.getClient(function(error, redis) {

    // use some native methods
    redis.client.scan(0, 'MATCH', 'user:*', 'COUNT', 500, function(err, resp) {
        console.log(resp);

        // don't forget to return the client to the pool when finished
        redis.done();
    });
});
```

can also be used with `async.js`
```javascript
async.auto({
    // get a redis client from the pool
    redis: function(fn) {
         redisCache.store.getClient(fn);
    },

    // use some native methods
    response: ['redis', function(fn, results) {
         results.redis.client.scan(0, 'MATCH', 'user:*', 'COUNT', 500, fn);
    }],

    // don't forget to return the client to the pool when finished
    close: ['response', function (fn, results) {
         // can also be used like
         // results.redis.done(fn, null, 'some other data');
         results.redis.done(fn);
    })
}, function(err, results) {
    console.log(err); // null
    console.log(results.response); // ['0', ['user:1', 'user:2', 'user:3']]
    // console.log(results.close); => 'some other data'
});
```