### PR TITLE
100% coverage

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,8 @@ function redisStore(args) {
     events: new EventEmitter()
   };
 
+  // cache-manager should always pass in args
+  /* istanbul ignore next */
   var redisOptions = args || {};
   var poolSettings = redisOptions;
 
@@ -28,6 +30,7 @@ function redisStore(args) {
         return cb(err);
       }
 
+      /* istanbul ignore else */
       if (args.db || args.db === 0) {
         conn.select(args.db);
       }
@@ -163,6 +166,12 @@ function redisStore(args) {
       });
     });
   };
+
+  /**
+   * Expose the raw pool object for testing purposes
+   * @private
+   */
+  self._pool = pool;
 
   return self;
 }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "codacy-coverage": "^1.1.3",
     "istanbul": "^0.4.0",
     "jasmine": "^2.3.2",
-    "jshint": "^2.8.0"
+    "jshint": "^2.8.0",
+    "sinon": "^1.17.2"
   }
 }


### PR DESCRIPTION
note: I had to expose the raw pool object (at `redisCache.store._pool`) in order to stub some error's in connect callbacks. I don't think this should cause any problems.