### PR TITLE
Added missing auth_pass parameter

### DIFF
--- a/spec/lib/redis-store-spec.js
+++ b/spec/lib/redis-store-spec.js
@@ -9,6 +9,7 @@ beforeAll(function() {
     store: redisStore,
     host: config.redis.host,
     port: config.redis.port,
+    auth_pass: config.redis.auth_pass,
     db: config.redis.db,
     ttl: config.redis.ttl
   });


### PR DESCRIPTION
The `beforeAll` method that creates the instance of `redisCache` was not making use of the `auth_pass` parameter. Thus, failing to create a valid `redisCache` instance.