### PR TITLE
Fix setting undefined so it returns an error and add tests.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 coverage
 docs
+.idea/

--- a/index.js
+++ b/index.js
@@ -57,7 +57,7 @@ function redisStore(args) {
    * Helper to handle callback and release the connection
    * @private
    * @param {Object} conn - The Redis connection
-   * @param {Function} [cb] - A callback that returns a potential error and the resoibse
+   * @param {Function} [cb] - A callback that returns a potential error and the result
    * @param {Object} [opts] - The options (optional)
    */
   function handleResponse(conn, cb, opts) {
@@ -73,7 +73,10 @@ function redisStore(args) {
       if (opts.parse) {
 
         try {
-          result = JSON.parse(result);
+          // allow undefined only if allowed by isCacheableValue
+          if(! ( (result === undefined || result === "undefined") && typeof args.isCacheableValue === 'function' && args.isCacheableValue(result))) {
+            result = JSON.parse(result);
+          }
         } catch (e) {
           return cb && cb(e);
         }
@@ -122,10 +125,6 @@ function redisStore(args) {
     if (typeof options === 'function') {
       cb = options;
       options = {};
-    }
-
-    if (value === undefined) {
-      return cb && cb(new Error('value cannot be undefined'));
     }
 
     options = options || {};

--- a/index.js
+++ b/index.js
@@ -71,7 +71,12 @@ function redisStore(args) {
       }
 
       if (opts.parse) {
-        result = JSON.parse(result);
+
+        try {
+          result = JSON.parse(result);
+        } catch (e) {
+          return cb && cb(e);
+        }
       }
 
       if (cb) {
@@ -113,10 +118,16 @@ function redisStore(args) {
    * @param {Function} [cb] - A callback that returns a potential error, otherwise null
    */
   self.set = function(key, value, options, cb) {
+
     if (typeof options === 'function') {
       cb = options;
       options = {};
     }
+
+    if (value === undefined) {
+      return cb && cb(new Error('value cannot be undefined'));
+    }
+
     options = options || {};
 
     var ttl = (options.ttl || options.ttl === 0) ? options.ttl : redisOptions.ttl;
@@ -126,7 +137,6 @@ function redisStore(args) {
         return cb && cb(err);
       }
       var val = JSON.stringify(value);
-
       if (ttl) {
         conn.setex(key, ttl, val, handleResponse(conn, cb));
       } else {

--- a/spec/lib/redis-store-spec.js
+++ b/spec/lib/redis-store-spec.js
@@ -50,13 +50,30 @@ describe('set', function() {
   });
 
   it('should not store an invalid value', function(done) {
-    redisCache.set('foo1', undefined, function(){
-      redisCache.get('foo1', function(err, value) {
+    redisCache.set('foo1', undefined, function(err){
+      try {
+        expect(err).notToBe(null);
+        expect(err.message).toEqual('value cannot be undefined');
+        done();
+      } catch (e) {
+        done(e);
+      }
+    });
+  });
+});
+
+it('should  store a null value without error', function(done) {
+  redisCache.set('foo2', null, function(err){
+    try {
+      expect(err).toBe(null);
+      redisCache.get('foo2', function(err, value) {
         expect(err).toBe(null);
         expect(value).toBe(null);
         done();
       });
-    });
+    } catch (e) {
+      done(e);
+    }
   });
 });
 


### PR DESCRIPTION
Newer redis version (post 3.0) changed handling of undefined value which caused problems and test failures.

This fix mitigates the problem.