### PR TITLE
Move db selection to the pool and default to 0

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,6 +25,7 @@ function redisStore(args) {
 
   redisOptions.host = args.host || '127.0.0.1';
   redisOptions.port = args.port || 6379;
+  redisOptions.db = args.db || 0;
 
   var pool = new RedisPool(redisOptions, poolSettings);
 
@@ -38,19 +39,7 @@ function redisStore(args) {
    * @param {Function} cb - A callback that returns
    */
   function connect(cb) {
-    pool.acquire(function(err, conn) {
-      if (err) {
-        pool.release(conn);
-        return cb(err);
-      }
-
-      /* istanbul ignore else */
-      if (args.db || args.db === 0) {
-        conn.select(args.db);
-      }
-
-      cb(null, conn);
-    });
+    pool.acquireDb(cb, redisOptions.db);
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -22,10 +22,10 @@
   "author": "Dial Once",
   "license": "MIT",
   "dependencies": {
-    "cache-manager": "^1.2.2",
     "sol-redis-pool": "^0.2.1"
   },
   "devDependencies": {
+    "cache-manager": "^2.1.2",
     "codacy-coverage": "^1.1.3",
     "istanbul": "^0.4.0",
     "jasmine": "^2.3.2",

--- a/spec/lib/redis-store-spec.js
+++ b/spec/lib/redis-store-spec.js
@@ -146,10 +146,10 @@ describe('get', function () {
 
   it('should return an error if there is an error acquiring a connection', function (done) {
     var pool = redisCache.store._pool;
-    sinon.stub(pool, 'acquire').yieldsAsync('Something unexpected');
+    sinon.stub(pool, 'acquireDb').yieldsAsync('Something unexpected');
     sinon.stub(pool, 'release');
     redisCache.get('foo', function (err) {
-      pool.acquire.restore();
+      pool.acquireDb.restore();
       pool.release.restore();
       expect(err).not.toBe(null);
       done();
@@ -176,11 +176,11 @@ describe('del', function () {
 
   it('should return an error if there is an error acquiring a connection', function (done) {
     var pool = redisCache.store._pool;
-    sinon.stub(pool, 'acquire').yieldsAsync('Something unexpected');
+    sinon.stub(pool, 'acquireDb').yieldsAsync('Something unexpected');
     sinon.stub(pool, 'release');
     redisCache.set('foo', 'bar', function () {
       redisCache.del('foo', function (err) {
-        pool.acquire.restore();
+        pool.acquireDb.restore();
         pool.release.restore();
         expect(err).not.toBe(null);
         done();
@@ -204,10 +204,10 @@ describe('reset', function () {
 
   it('should return an error if there is an error acquiring a connection', function (done) {
     var pool = redisCache.store._pool;
-    sinon.stub(pool, 'acquire').yieldsAsync('Something unexpected');
+    sinon.stub(pool, 'acquireDb').yieldsAsync('Something unexpected');
     sinon.stub(pool, 'release');
     redisCache.reset(function (err) {
-      pool.acquire.restore();
+      pool.acquireDb.restore();
       pool.release.restore();
       expect(err).not.toBe(null);
       done();
@@ -236,11 +236,11 @@ describe('ttl', function () {
 
   it('should return an error if there is an error acquiring a connection', function (done) {
     var pool = redisCache.store._pool;
-    sinon.stub(pool, 'acquire').yieldsAsync('Something unexpected');
+    sinon.stub(pool, 'acquireDb').yieldsAsync('Something unexpected');
     sinon.stub(pool, 'release');
     redisCache.set('foo', 'bar', function () {
       redisCache.ttl('foo', function (err) {
-        pool.acquire.restore();
+        pool.acquireDb.restore();
         pool.release.restore();
         expect(err).not.toBe(null);
         done();
@@ -274,11 +274,11 @@ describe('keys', function () {
 
   it('should return an error if there is an error acquiring a connection', function (done) {
     var pool = redisCache.store._pool;
-    sinon.stub(pool, 'acquire').yieldsAsync('Something unexpected');
+    sinon.stub(pool, 'acquireDb').yieldsAsync('Something unexpected');
     sinon.stub(pool, 'release');
     redisCache.set('foo', 'bar', function () {
       redisCache.keys('f*', function (err) {
-        pool.acquire.restore();
+        pool.acquireDb.restore();
         pool.release.restore();
         expect(err).not.toBe(null);
         done();
@@ -325,10 +325,10 @@ describe('getClient', function () {
 
   it('should return an error if there is an error acquiring a connection', function (done) {
     var pool = redisCache.store._pool;
-    sinon.stub(pool, 'acquire').yieldsAsync('Something unexpected');
+    sinon.stub(pool, 'acquireDb').yieldsAsync('Something unexpected');
     sinon.stub(pool, 'release');
     redisCache.store.getClient(function (err) {
-      pool.acquire.restore();
+      pool.acquireDb.restore();
       pool.release.restore();
       expect(err).not.toBe(null);
       done();


### PR DESCRIPTION
This moves the selection of the database to the pool and also defaults it to 0. This way `sol-redis-pool` can track the database selection and avoid selecting the database more than once per connection.

Without this I were seeing a select on each release of the connection, which essentially doubles the number of Redis requests per lookup.
