### PR TITLE
Feature/destroy connection on err

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,11 +65,12 @@ function redisStore(args) {
     opts = opts || {};
 
     return function(err, result) {
-      pool.release(conn);
-
       if (err) {
+        pool.destroy(conn);
         return cb && cb(err);
       }
+
+      pool.release(conn);
 
       if (opts.parse) {
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "cache-manager": "^1.2.2",
     "redis-url": "^1.2.1",
-    "sol-redis-pool": "^0.2.1"
+    "sol-redis-pool": "^0.3.0"
   },
   "devDependencies": {
     "codacy-coverage": "^1.1.3",


### PR DESCRIPTION
I'm attempting to solve an issue where a closed connection remains a part of the redis pool and is returned once again when a new connection is requested. By destroying the connection if the connection fails, a new connection is returned when requested and it will attempt once again to connect to redis.

Here are my reproduction steps:

1. Create a new redis cache with max_attempts set to 1, or retry_strategy implemented (anything will work as long as it eventually gives up trying to connect). Start up redis, verify that the redis cache is working properly.
2. Turn off redis. Verify that the cache fails to reach redis and cannot retrieve or set data.
3. Turn redis back on. See that the redis connection will continue to fail to connect (the one exception seems to be if no attempts are made for a while, and the connection is destroyed due to inactivity).

Here is the issue & pull request I filed in sol-redis-pool to attempt to get the destroy method made public:

https://github.com/joshuah/sol-redis-pool/issues/18

https://github.com/joshuah/sol-redis-pool/pull/19/commits/f9141b3e17ef5747b6265b2474dbd9190470f1a9

If I'm way off here and misunderstanding what's going on, please let me know. I'm hoping to have this fixed soon as we're looking to roll it out in production.