### PR TITLE
Add support for password instead of auth_pass

### DIFF
--- a/index.js
+++ b/index.js
@@ -129,7 +129,8 @@ function redisStore(args) {
   }
 
   /**
-   * Apply some options like hostname , port, db, ttl auth_pass from options to newArgs host, port, db, auth_pass and ttl and return clone of args
+   * Apply some options like hostname, port, db, ttl, auth_pass, password
+   * from options to newArgs host, port, db, auth_pass, password and ttl and return clone of args
    * @param {Object} args
    * @param {Object} options
    * @returns {Object} clone of args param with properties set to those of options
@@ -140,6 +141,7 @@ function redisStore(args) {
     newArgs.port = parseInt(options.port, 10);
     newArgs.db = parseInt(options.database, 10);
     newArgs.auth_pass = options.password;
+    newArgs.password = options.password;
     if(options.query && options.query.ttl){
       newArgs.ttl = parseInt(options.query.ttl, 10);
     }


### PR DESCRIPTION
Since auth_pass is being deprecated (redis > 2.5) in favour of password
this allows it's support and tests the behaviour
https://github.com/NodeRedis/node_redis