### PR TITLE
If value is undefined, store it as empty string (Redis 3.x)

### DIFF
--- a/index.js
+++ b/index.js
@@ -199,7 +199,7 @@ function redisStore(args) {
       if (err) {
         return cb && cb(err);
       }
-      var val = JSON.stringify(value);
+      var val = JSON.stringify(value) || 'undefined';
       if (ttl) {
         conn.setex(key, ttl, val, handleResponse(conn, cb));
       } else {


### PR DESCRIPTION
This was deprecated and triggers a warning on redis 2.x, but is removed from redis 3.x and crashes the module/tests.

This fixes the warnings:
```
node_redis: Deprecated: The SETEX command contains a "undefined" argument.
This is converted to a "undefined" string now and will return an error from v.3.0 on.
```

Reviewers: @dial-once/developers 