### PR TITLE
Feature/undefined json

### DIFF
--- a/index.js
+++ b/index.js
@@ -183,7 +183,7 @@ function redisStore(args) {
       options = {};
     }
 
-    if (!value && !self.isCacheableValue(value)) {
+    if (!self.isCacheableValue(value)) {
       return cb(new Error('value cannot be ' + value));
     }
 

--- a/index.js
+++ b/index.js
@@ -72,12 +72,8 @@ function redisStore(args) {
       }
 
       if (opts.parse) {
-
         try {
-          // allow undefined only if allowed by isCacheableValue
-          if(! ( (result === undefined || result === 'undefined') && typeof args.isCacheableValue === 'function' && args.isCacheableValue(result))) {
-            result = JSON.parse(result);
-          }
+          result = JSON.parse(result);
         } catch (e) {
           return cb && cb(e);
         }
@@ -199,7 +195,7 @@ function redisStore(args) {
       if (err) {
         return cb && cb(err);
       }
-      var val = JSON.stringify(value) || 'undefined';
+      var val = JSON.stringify(value) || '"undefined"';
       if (ttl) {
         conn.setex(key, ttl, val, handleResponse(conn, cb));
       } else {


### PR DESCRIPTION
See #47 

This PR stores undefined values as JSON parseable strings and simplifies the `handleResponse` code. It also fixes an error when disallowing truthy values with custom `isCacheableValue` functions.