### PR TITLE
Feature/store null values

### DIFF
--- a/index.js
+++ b/index.js
@@ -277,7 +277,7 @@ function redisStore(args) {
   /**
    * Specify which values should and should not be cached.
    * If the function returns true, it will be stored in cache.
-   * By default, it caches everything except null and undefined values.
+   * By default, it caches everything except undefined values.
    * Can be overriden via standard node-cache-manager options.
    * @method isCacheableValue
    * @param {String} value - The value to check

--- a/index.js
+++ b/index.js
@@ -284,7 +284,7 @@ function redisStore(args) {
    * @return {Boolean} - Returns true if the value is cacheable, otherwise false.
    */
   self.isCacheableValue = args.isCacheableValue || function(value) {
-    return value !== null && value !== undefined;
+    return value !== undefined;
   };
 
   /**

--- a/test/lib/redis-store-spec.js
+++ b/test/lib/redis-store-spec.js
@@ -5,7 +5,6 @@ var assert = require('assert');
 
 var redisCache;
 var customRedisCache;
-var customRedisCache2;
 
 before(function () {
   redisCache = require('cache-manager').caching({
@@ -25,20 +24,11 @@ before(function () {
     ttl: config.redis.ttl,
     isCacheableValue: function (val) {
       // allow undefined
-      if (val === undefined) return true;
-      return redisCache.store.isCacheableValue(val);
-    }
-  });
-
-  customRedisCache2 = require('cache-manager').caching({
-    store: redisStore,
-    host: config.redis.host,
-    port: config.redis.port,
-    db: config.redis.db,
-    ttl: config.redis.ttl,
-    isCacheableValue: function (val) {
+      if (val === undefined)
+        return true;
       // disallow FooBarString
-      if (val === 'FooBarString') return false;
+      else if (val === 'FooBarString')
+        return false;
       return redisCache.store.isCacheableValue(val);
     }
   });
@@ -92,20 +82,20 @@ describe('set', function () {
         done();
       });
     });
+  });
 
-    it('should store a null value without error', function (done) {
-      redisCache.set('foo2', null, function (err) {
-        try {
+  it('should store a null value without error', function (done) {
+    redisCache.set('foo2', null, function (err) {
+      try {
+        assert.equal(err, null);
+        redisCache.get('foo2', function (err, value) {
           assert.equal(err, null);
-          redisCache.get('foo2', function (err, value) {
-            assert.equal(err, null);
-            assert.equal(value, null);
-            done();
-          });
-        } catch (e) {
-          done(e);
-        }
-      });
+          assert.equal(value, null);
+          done();
+        });
+      } catch (e) {
+        done(e);
+      }
     });
   });
 
@@ -130,7 +120,7 @@ describe('set', function () {
     });
   });
 
-  it('should  store an undefined value if permitted by isCacheableValue', function (done) {
+  it('should store an undefined value if permitted by isCacheableValue', function (done) {
     assert(customRedisCache.store.isCacheableValue(undefined), true);
     customRedisCache.set('foo3', undefined, function (err) {
       try {
@@ -152,8 +142,8 @@ describe('set', function () {
   });
 
   it('should not store a value disallowed by isCacheableValue', function (done) {
-    assert.strictEqual(customRedisCache2.store.isCacheableValue('FooBarString'), false);
-    customRedisCache2.set('foobar', 'FooBarString', function (err) {
+    assert.strictEqual(customRedisCache.store.isCacheableValue('FooBarString'), false);
+    customRedisCache.set('foobar', 'FooBarString', function (err) {
       try {
         assert.notEqual(err, null);
         assert.equal(err.message, 'value cannot be FooBarString');
@@ -341,16 +331,16 @@ describe('keys', function () {
 });
 
 describe('isCacheableValue', function () {
-  it('should return true when the value is not null or undefined', function (done) {
+  it('should return true when the value is not undefined', function (done) {
     assert.equal(redisCache.store.isCacheableValue(0), true);
     assert.equal(redisCache.store.isCacheableValue(100), true);
     assert.equal(redisCache.store.isCacheableValue(''), true);
     assert.equal(redisCache.store.isCacheableValue('test'), true);
+    assert.equal(redisCache.store.isCacheableValue(null), true);
     done();
   });
 
-  it('should return false when the value is null or undefined', function (done) {
-    assert.equal(redisCache.store.isCacheableValue(null), false);
+  it('should return false when the value is undefined', function (done) {
     assert.equal(redisCache.store.isCacheableValue(undefined), false);
     done();
   });


### PR DESCRIPTION
The test for storing null values without an error was not being run due to a typo. After fixing the test, it immediately started to fail. The default `isCacheableValue` function was not allowing null values. This PR contains the test fix, as well as a change to `isCacheableValue` to allow null values. It also modifies the `isCacheableValue` tests to reflect these changes.

I have also removed the extra `customRedisCache2` object I previously added to the test file and combined my changes with the original `customRedisCache` object to reduce clutter.