### PR TITLE
Update cache-manager and sol-redis-pool dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,9 +22,9 @@
   "author": "Dial Once",
   "license": "MIT",
   "dependencies": {
-    "cache-manager": "^1.2.2",
+    "cache-manager": "^2.2.0",
     "redis-url": "^1.2.1",
-    "sol-redis-pool": "^0.3.1"
+    "sol-redis-pool": "^0.3.2"
   },
   "devDependencies": {
     "istanbul": "^0.4.0",


### PR DESCRIPTION
This PR updates the `cache-manager` dependency to `2.2.0` and the `sol-redis-pool` dependency to `0.3.2`. This closes issue #54.