### PR TITLE
Ensure options object is initialized in self.get when using promises.

### DIFF
--- a/index.js
+++ b/index.js
@@ -180,6 +180,7 @@ function redisStore(args) {
       cb = options;
       options = {};
     }
+    options = options || {};
     options.parse = true;
 
     var compress = (options.compress || options.compress === false) ? options.compress : redisOptions.compress;


### PR DESCRIPTION
When using the `.wrap` method with promises, it is possible for the `options` object to not be properly initialized in `self.get`. I have added an explicit initialization on line 183 to fix this error. I have also added promise-based tests for the `.wrap` method to both spec files.

This resolves #59.

Sorry for all the issues! This should probably go as `0.3.1` as soon as you guys have reviewed it. Hopefully, this will be the last of the problems with the `.wrap` function.