### PR TITLE
Missing `cb &&` on set

### DIFF
--- a/index.js
+++ b/index.js
@@ -216,7 +216,7 @@ function redisStore(args) {
     }
 
     if (!self.isCacheableValue(value)) {
-      return cb(new Error('value cannot be ' + value));
+      return cb && cb(new Error('value cannot be ' + value));
     }
 
     options = options || {};

--- a/test/lib/redis-store-spec.js
+++ b/test/lib/redis-store-spec.js
@@ -86,12 +86,12 @@ describe('set', function () {
   });
 
   it('should not be able to store a null value (not cacheable)', function (done) {
-    try {
-      redisCache.set('foo2', null);
+    redisCache.set('foo2', null, function (err) {
+      if (err) {
+        return done();
+      }
       done(new Error('Null is not a valid value!'));
-    } catch (e) {
-      done();
-    }
+    });
   });
 
   it('should store a value without callback', function (done) {


### PR DESCRIPTION
Following a pattern that's used throughout the library which fixes an issue when using promises.