### PR TITLE
Feature/scan and multi delete

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,17 @@ redisCache.wrap(key, function (cb) {
         console.log(user);
     });
 });
+
+// The del() method accepts a single key or array of keys,
+// with or without a callback.
+redisCache.set('foo', 'bar', function () {
+  redisCache.set('bar', 'baz', function() {
+    redisCache.set('baz', 'foo', function() {
+      redisCache.del('foo');
+      redisCache.del(['bar', 'baz'], function() { });
+    });
+  });
+});
 ```
 
 ### Multi-store

--- a/README.md
+++ b/README.md
@@ -79,13 +79,37 @@ redisCache.wrap(key, function (cb) {
 // The del() method accepts a single key or array of keys,
 // with or without a callback.
 redisCache.set('foo', 'bar', function () {
-  redisCache.set('bar', 'baz', function() {
-    redisCache.set('baz', 'foo', function() {
-      redisCache.del('foo');
-      redisCache.del(['bar', 'baz'], function() { });
+    redisCache.set('bar', 'baz', function() {
+        redisCache.set('baz', 'foo', function() {
+          redisCache.del('foo');
+          redisCache.del(['bar', 'baz'], function() { });
+        });
     });
-  });
 });
+
+// The keys() method uses the Redis SCAN command and accepts
+// optional `pattern` and `options` arguments. The `pattern`
+// must be a Redis glob-style string and defaults to '*'. The
+// options argument must be an object and accepts a single
+// `scanCount` property, which determines the number of elements
+// returned internally per call to SCAN. The default `scanCount`
+// is 100.
+redisCache.set('foo', 'bar', function () {
+    redisCache.set('far', 'boo', function () {
+        redisCache.keys('fo*', function (err, arrayOfKeys) {
+            // arrayOfKeys: ['foo']
+        });
+        
+        redisCache.keys(function (err, arrayOfKeys) {
+            // arrayOfKeys: ['foo', 'far']
+        });
+        
+        redisCache.keys('fa*', { scanCount: 10 }, function (err, arrayOfKeys) {
+            // arrayOfKeys: ['far']
+        });
+    });
+});
+
 ```
 
 ### Multi-store

--- a/index.js
+++ b/index.js
@@ -360,7 +360,7 @@ function redisStore(args) {
 
       // Use an object to dedupe as scan can return duplicates
       var keysObj = {};
-      var scanCount = options.scanCount || 100;
+      var scanCount = Number(options.scanCount) || 100;
 
       (function nextBatch(cursorId) {
         conn.scan(cursorId, 'match', pattern, 'count', scanCount, function (err, result) {

--- a/index.js
+++ b/index.js
@@ -365,7 +365,7 @@ function redisStore(args) {
       (function nextBatch(cursorId) {
         conn.scan(cursorId, 'match', pattern, 'count', scanCount, function (err, result) {
           if (err) {
-            return cb && cb(err);
+            handleResponse(conn, cb)(err);
           }
 
           var nextCursorId = result[0];
@@ -379,8 +379,7 @@ function redisStore(args) {
             return nextBatch(nextCursorId);
           }
 
-          pool.release(conn);
-          return cb && cb(null, Object.keys(keysObj));
+          handleResponse(conn, cb)(null, Object.keys(keysObj));
         });
       })(0);
     });

--- a/index.js
+++ b/index.js
@@ -186,7 +186,7 @@ function redisStore(args) {
       options = options || {};
       options.parse = true;
 
-      cb = cb ? cb : (err, result) => err ? reject(err) : resolve(result)
+      cb = cb ? cb : (err, result) => err ? reject(err) : resolve(result);
 
       var compress = (options.compress || options.compress === false) ? options.compress : redisOptions.compress;
       if (compress) {
@@ -222,7 +222,7 @@ function redisStore(args) {
         options = {};
       }
 
-      cb = cb ? cb : (err, result) => err ? reject(err) : resolve(result)
+      cb = cb ? cb : (err, result) => err ? reject(err) : resolve(result);
 
       if (!self.isCacheableValue(value)) {
         return cb(new Error('value cannot be ' + value));

--- a/index.js
+++ b/index.js
@@ -351,20 +351,20 @@ function redisStore(args) {
             return cb && cb(err);
           }
 
-          var nextCursorId = Number(result[0]);
+          var nextCursorId = result[0];
           var keys = result[1];
 
           for (var i = 0, l = keys.length; i < l; ++i) {
             keysObj[keys[i]] = 1;
           }
 
-          if (nextCursorId !== 0) {
+          if (nextCursorId !== '0') {
             return nextBatch(nextCursorId);
           }
 
           pool.release(conn);
           return cb && cb(null, Object.keys(keysObj));
-        })
+        });
       })(0);
     });
   };

--- a/index.js
+++ b/index.js
@@ -328,12 +328,19 @@ function redisStore(args) {
    * Returns all keys matching pattern using the SCAN command.
    * @method keys
    * @param {String} pattern - The pattern used to match keys
+   * @param {Object} [options] - The options (optional)
+   * @param {number} [options.scanCount] - The number of keys to traverse with each call to SCAN (default: 100)
    * @param {Function} cb - A callback that returns a potential error and the response
    */
-  self.keys = function(pattern, cb) {
+  self.keys = function(pattern, options, cb) {
     if (typeof pattern === 'function') {
       cb = pattern;
       pattern = '*';
+      options = {};
+    }
+    else if (typeof options === 'function') {
+      cb = options;
+      options = {};
     }
 
     connect(function(err, conn) {
@@ -343,10 +350,10 @@ function redisStore(args) {
 
       // Use an object to dedupe as scan can return duplicates
       var keysObj = {};
-      var count = 100;
+      var scanCount = options.scanCount || 100;
 
       (function nextBatch(cursorId) {
-        conn.scan(cursorId, 'match', pattern, 'count', count, function (err, result) {
+        conn.scan(cursorId, 'match', pattern, 'count', scanCount, function (err, result) {
           if (err) {
             return cb && cb(err);
           }

--- a/index.js
+++ b/index.js
@@ -327,17 +327,27 @@ function redisStore(args) {
   /**
    * Returns all keys matching pattern using the SCAN command.
    * @method keys
-   * @param {String} pattern - The pattern used to match keys
-   * @param {Object} [options] - The options (optional)
+   * @param {String} [pattern] - The pattern used to match keys (default: *)
+   * @param {Object} [options] - The options (default: {})
    * @param {number} [options.scanCount] - The number of keys to traverse with each call to SCAN (default: 100)
    * @param {Function} cb - A callback that returns a potential error and the response
    */
   self.keys = function(pattern, options, cb) {
+
+    // Account for all argument permutations.
+    // Only cb supplied.
     if (typeof pattern === 'function') {
       cb = pattern;
-      pattern = '*';
       options = {};
+      pattern = '*';
     }
+    // options and cb supplied.
+    else if (typeof pattern === 'object') {
+      cb = options;
+      options = pattern;
+      pattern = '*';
+    }
+    // pattern and cb supplied.
     else if (typeof options === 'function') {
       cb = options;
       options = {};

--- a/index.js
+++ b/index.js
@@ -282,7 +282,7 @@ function redisStore(args) {
         return cb && cb(err);
       }
 
-      if (Object.prototype.toString.call(key) === '[object Array]') {
+      if (Array.isArray(key)) {
         var multi = conn.multi();
         for (var i = 0, l = key.length; i < l; ++i) {
           multi.del(key[i]);

--- a/index.js
+++ b/index.js
@@ -267,7 +267,7 @@ function redisStore(args) {
   /**
    * Delete value of a given key
    * @method del
-   * @param {String} key - The cache key
+   * @param {String|Array} key - The cache key or array of keys to delete
    * @param {Object} [options] - The options (optional)
    * @param {Function} [cb] - A callback that returns a potential error, otherwise null
    */
@@ -281,7 +281,17 @@ function redisStore(args) {
       if (err) {
         return cb && cb(err);
       }
-      conn.del(key, handleResponse(conn, cb));
+
+      if (Object.prototype.toString.call(key) === '[object Array]') {
+        var multi = conn.multi();
+        for (var i = 0, l = key.length; i < l; ++i) {
+          multi.del(key[i]);
+        }
+        multi.exec(handleResponse(conn, cb));
+      }
+      else {
+        conn.del(key, handleResponse(conn, cb));
+      }
     });
   };
 

--- a/test/lib/redis-store-spec.js
+++ b/test/lib/redis-store-spec.js
@@ -383,7 +383,7 @@ describe('keys', function () {
     redisCache.set('foo', 'bar', function () {
       redisCache.set('far', 'boo', function () {
         redisCache.set('faz', 'bam', function () {
-          redisCache.keys('f*', function (err, arrayOfKeys) {
+          redisCache.keys('f*', { scanCount: 10 }, function (err, arrayOfKeys) {
             assert.equal(err, null);
             assert.notEqual(arrayOfKeys, null);
             assert.notEqual(arrayOfKeys.indexOf('foo'), -1);
@@ -400,6 +400,22 @@ describe('keys', function () {
       redisCache.set('far', 'boo', function () {
         redisCache.set('faz', 'bam', function () {
           redisCache.keys(function (err, arrayOfKeys) {
+            assert.equal(err, null);
+            assert.notEqual(arrayOfKeys, null);
+            assert.notEqual(arrayOfKeys.indexOf('foo'), -1);
+            assert.equal(arrayOfKeys.length, 3);
+            done();
+          });
+        });
+      });
+    });
+  });
+
+  it('should accept scanCount option without pattern', function (done) {
+    redisCache.set('foo', 'bar', function () {
+      redisCache.set('far', 'boo', function () {
+        redisCache.set('faz', 'bam', function () {
+          redisCache.keys({ scanCount: 10 }, function (err, arrayOfKeys) {
             assert.equal(err, null);
             assert.notEqual(arrayOfKeys, null);
             assert.notEqual(arrayOfKeys.indexOf('foo'), -1);

--- a/test/lib/redis-store-spec.js
+++ b/test/lib/redis-store-spec.js
@@ -257,6 +257,30 @@ describe('del', function () {
     });
   });
 
+  it('should delete multiple values for a given array of keys', function (done) {
+    redisCache.set('foo', 'bar', function () {
+      redisCache.set('bar', 'baz', function () {
+        redisCache.set('baz', 'foo', function () {
+          redisCache.del(['foo', 'bar', 'baz'], function (err) {
+            assert.equal(err, null);
+            done();
+          });
+        });
+      });
+    });
+  });
+
+  it('should delete multiple values for a given array of keys without callback', function (done) {
+    redisCache.set('foo', 'bar', function () {
+      redisCache.set('bar', 'baz', function () {
+        redisCache.set('baz', 'foo', function () {
+          redisCache.del(['foo', 'bar', 'baz']);
+          done();
+        });
+      });
+    });
+  });
+
   it('should return an error if there is an error acquiring a connection', function (done) {
     var pool = redisCache.store._pool;
     sinon.stub(pool, 'acquireDb').yieldsAsync('Something unexpected');

--- a/test/lib/redis-store-spec.js
+++ b/test/lib/redis-store-spec.js
@@ -35,6 +35,12 @@ before(function () {
   });
 });
 
+beforeEach(function(done) {
+  redisCache.reset(function() {
+    done();
+  });
+});
+
 describe ('initialization', function () {
 
   it('should create a store with password instead of auth_pass (auth_pass is deprecated for redis > 2.5)', function (done) {
@@ -359,22 +365,48 @@ describe('ttl', function () {
 describe('keys', function () {
   it('should return an array of keys for the given pattern', function (done) {
     redisCache.set('foo', 'bar', function () {
-      redisCache.keys('f*', function (err, arrayOfKeys) {
-        assert.equal(err, null);
-        assert.notEqual(arrayOfKeys, null);
-        assert.notEqual(arrayOfKeys.indexOf('foo'), -1);
-        done();
+      redisCache.set('far', 'boo', function () {
+        redisCache.set('faz', 'bam', function () {
+          redisCache.keys('f*', function (err, arrayOfKeys) {
+            assert.equal(err, null);
+            assert.notEqual(arrayOfKeys, null);
+            assert.notEqual(arrayOfKeys.indexOf('foo'), -1);
+            assert.equal(arrayOfKeys.length, 3);
+            done();
+          });
+        });
+      });
+    });
+  });
+
+  it('should accept a scanCount option', function (done) {
+    redisCache.set('foo', 'bar', function () {
+      redisCache.set('far', 'boo', function () {
+        redisCache.set('faz', 'bam', function () {
+          redisCache.keys('f*', function (err, arrayOfKeys) {
+            assert.equal(err, null);
+            assert.notEqual(arrayOfKeys, null);
+            assert.notEqual(arrayOfKeys.indexOf('foo'), -1);
+            assert.equal(arrayOfKeys.length, 3);
+            done();
+          });
+        });
       });
     });
   });
 
   it('should return an array of keys without pattern', function (done) {
     redisCache.set('foo', 'bar', function () {
-      redisCache.keys(function (err, arrayOfKeys) {
-        assert.equal(err, null);
-        assert.notEqual(arrayOfKeys, null);
-        assert.notEqual(arrayOfKeys.indexOf('foo'), -1);
-        done();
+      redisCache.set('far', 'boo', function () {
+        redisCache.set('faz', 'bam', function () {
+          redisCache.keys(function (err, arrayOfKeys) {
+            assert.equal(err, null);
+            assert.notEqual(arrayOfKeys, null);
+            assert.notEqual(arrayOfKeys.indexOf('foo'), -1);
+            assert.equal(arrayOfKeys.length, 3);
+            done();
+          });
+        });
       });
     });
   });

--- a/test/lib/redis-store-zlib-spec.js
+++ b/test/lib/redis-store-zlib-spec.js
@@ -42,6 +42,12 @@ describe('Compression Tests', function () {
     testJson = JSON.stringify(testObject);
   });
 
+  beforeEach(function(done) {
+    redisCompressCache.reset(function () {
+      done();
+    });
+  });
+
   describe('compress set', function () {
     it('should store a value without ttl', function (done) {
       redisCompressCache.set('foo', 'bar', function (err) {


### PR DESCRIPTION
Hi Guys,

I was looking through the `connect-redis` module, recently, and got some inspiration for the following! This PR changes the `keys()` method to use the redis `scan` command (#71), which is the recommended way to retrieve keys with a pattern in production. It also adds the ability to pass an array of keys to the `del()` method (#27).

The change to `keys()` utilizes the existing tests and there is no outward change for the end user. I have added tests for the change to `del()`, as well as a blurb in the README.

There were also a couple of missing semi-colons that I noticed and added...   😄 

Let me know what you think. Hope you are all doing well!